### PR TITLE
don't install test/dev gems in Container builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qq && \
 ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
-    BUNDLE_WITHOUT="development" \
+    BUNDLE_WITHOUT="development test" \
     LD_PRELOAD="/usr/local/lib/libjemalloc.so"
 
 


### PR DESCRIPTION
Containerfile was only ignoring gems in the `:development` group of the Gemfile. gems in both the `:test` and `:development, :test` groups were being installed when running container builds. ignoring them improves build times and brings down images sizes further.