### PR TITLE
[feat] add `/.well-known/links` endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem "bootsnap", require: false
 gem "commonmarker"
 gem "image_processing", "~> 1.2"
 gem "importmap-rails"
+gem "jbuilder"
 gem "jwt"
 gem "pagy", "~> 43.5.1"
 gem "pg", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,9 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
+    jbuilder (2.14.1)
+      actionview (>= 7.0.0)
+      activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.19.3)
     jwt (3.1.2)
@@ -450,6 +453,7 @@ DEPENDENCIES
   faker
   image_processing (~> 1.2)
   importmap-rails
+  jbuilder
   jwt
   marksmith (~> 0.4.8)
   nokogiri

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class LinksController < ApplicationController
+  def index
+    @links = Link
+      .includes(:posts)
+      .select(:id, :target_domain, :target_url)
+      .group(:target_domain, :target_url, :id)
+      .order("COUNT(target_domain) DESC, target_url ASC")
+  end
+end

--- a/app/views/links/index.json.jbuilder
+++ b/app/views/links/index.json.jbuilder
@@ -1,0 +1,26 @@
+def target_url(link)
+  return link.target_url unless link.internal?
+
+  URI.parse(root_url).tap do |uri|
+    uri.path = link.target_url.to_s
+  end
+end
+
+json.array! @links.pluck(:target_domain).uniq do |domain|
+  json.domain domain || root_url
+  domain_links = @links.select { |link| link.target_domain == domain }
+  json.count domain_links.count
+
+  json.links do
+    domain_links.each do |domain_link|
+      domain_link.posts.each do |post|
+        target_url = target_url(domain_link)
+
+        json.child! do
+          json.sourceUrl post_url(post)
+          json.targetUrl target_url
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -23,6 +25,10 @@ Rails.application.routes.draw do
 
   root "posts#index"
   get :feed, to: "posts#index", defaults: {format: :xml}
+
+  scope ".well-known" do
+    resources :links, only: :index, to: "links#index", defaults: {format: :json}
+  end
 
   # redirect all unrecognized paths to the root path.
   # match "*path" => "posts#index", via: %i[get post put patch delete], to: redirect("/")

--- a/spec/requests/links_spec.rb
+++ b/spec/requests/links_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe "Links", type: :request do
+  describe "GET /.well-known/links" do
+    let(:post) { create(:post) }
+    let(:linked_post) { create(:post) }
+    let!(:external_link) { create(:link, posts: [post], target_url: "https://abc.xyz/first") }
+    let!(:internal_link) { create(:link, target_url: post_path(linked_post), posts: [post]) }
+    let!(:second_external_link_same_domain) { create(:link, target_url: "https://abc.xyz/second", posts: [linked_post]) }
+
+    it "returns the expected data in the correct format" do
+      get links_path
+
+      expect(response.parsed_body.map(&:deep_symbolize_keys)).to eq([
+        {
+          domain: external_link.target_domain,
+          count: 2,
+          links: [
+            {
+              targetUrl: external_link.target_url.to_s,
+              sourceUrl: post_url(post)
+            },
+            {
+              targetUrl: second_external_link_same_domain.target_url.to_s,
+              sourceUrl: post_url(linked_post)
+            }
+          ]
+        },
+        {
+          domain: root_url,
+          count: 1,
+          links: [
+            {
+              targetUrl: post_url(linked_post),
+              sourceUrl: post_url(post)
+            }
+          ]
+        }
+      ])
+    end
+  end
+end


### PR DESCRIPTION
returns links included in blog posts, sorted by frequency of each linked domain, in descending order, and in ascending order alphabetically by target url