### PR TITLE
fix link ordering logic

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -2,10 +2,11 @@
 
 class LinksController < ApplicationController
   def index
-    @links = Link
-      .includes(:posts)
-      .select(:id, :target_domain, :target_url)
-      .group(:target_domain, :target_url, :id)
-      .order("COUNT(target_domain) DESC, target_url ASC")
+    @link_domains = Link
+      .select(:target_domain, "COUNT(target_domain IS NULL) as domain_freq")
+      .group(:target_domain)
+      .order("domain_freq DESC, target_domain ASC")
+
+    @links = Link.includes(:posts).select(:id, :target_domain, :target_url)
   end
 end

--- a/app/views/links/index.json.jbuilder
+++ b/app/views/links/index.json.jbuilder
@@ -6,10 +6,11 @@ def target_url(link)
   end
 end
 
-json.array! @links.pluck(:target_domain).uniq do |domain|
+json.array! @link_domains.each do |link_domain|
+  domain = link_domain.target_domain
   json.domain domain || root_url
   domain_links = @links.select { |link| link.target_domain == domain }
-  json.count domain_links.count
+  json.count link_domain.domain_freq
 
   json.links do
     domain_links.each do |domain_link|


### PR DESCRIPTION
need to first perform a query that groups by target_domain only in order to get an accurate COUNT, then perform another query to retrieve the other data that's relevant for rendering. so overall, there will be 4 queries per request. not _awful_.