### PR TITLE
for internal links, extract host from root_url

### DIFF
--- a/app/views/links/index.json.jbuilder
+++ b/app/views/links/index.json.jbuilder
@@ -8,7 +8,7 @@ end
 
 json.array! @link_domains.each do |link_domain|
   domain = link_domain.target_domain
-  json.domain domain || root_url
+  json.domain domain || URI.parse(root_url).host
   domain_links = @links.select { |link| link.target_domain == domain }
   json.count link_domain.domain_freq
 

--- a/spec/requests/links_spec.rb
+++ b/spec/requests/links_spec.rb
@@ -27,7 +27,7 @@ describe "Links", type: :request do
           ]
         },
         {
-          domain: root_url,
+          domain: URI.parse(root_url).host,
           count: 1,
           links: [
             {


### PR DESCRIPTION
the `domain` for internal links was the host URL, not the plain domain.